### PR TITLE
Don't test Node.js 0.8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
 git:
   depth: 10


### PR DESCRIPTION
nock doesn't support 0.8 due to use of `setImmediate`: https://github.com/pgte/nock/commit/09f9289ef878c0db5e9951399af9f928a8748f19